### PR TITLE
bug fixes

### DIFF
--- a/src/main/java/dev/justix/gtavtools/tools/casino/FingerprintHack.java
+++ b/src/main/java/dev/justix/gtavtools/tools/casino/FingerprintHack.java
@@ -34,10 +34,10 @@ public class FingerprintHack extends Tool {
 
         relativeData.addRect("1920x1080", "components_text", 546, 220, 26, 18);
         relativeData.addRect("1920x1080", "expected", 960, 157, 410, 516);
-        relativeData.addRect("1920x1080", "expected_resized", 0, 0, 306, 380);
-        relativeData.addPoint("1920x1080", "part_start_coordinates", 481, 278);
-        relativeData.add("1920x1080", "part_size", 107);
-        relativeData.add("1920x1080", "part_step", 146);
+        relativeData.addRect("1920x1080", "expected_resized", 0, 0, 328, 406);
+        relativeData.addPoint("1920x1080", "part_start_coordinates", 480, 277);
+        relativeData.add("1920x1080", "part_size", 106);
+        relativeData.add("1920x1080", "part_step", 144);
 
         this.cancel = false;
     }
@@ -53,7 +53,7 @@ public class FingerprintHack extends Tool {
             new RescaleOp(2f, -32, null).filter(expectedCapture, expectedCapture);
 
             final BufferedImage expectedResized = transform(expectedCapture, relativeData.getRect("expected_resized"), false);
-            final int[][] expectedPixels = getPixels(expectedResized, 50, 120, 50, 120, 50, 120, false);
+            final int[][] expectedPixels = getPixels(expectedResized, 20, 180, 20, 180, 20, 180, false);
             final int blockSize = BlockMatrixConverter.getBlockSize(expectedPixels);
             final BlockMatrix expected = BlockMatrixConverter.convertPixels(expectedPixels, blockSize);
 
@@ -132,7 +132,7 @@ public class FingerprintHack extends Tool {
                 sleep(15);
             }
 
-            sleep(4_350);
+            sleep(4_500);
 
             BufferedImage textCapture = screenshot(relativeData.getRect("components_text"));
             new RescaleOp(0.85f, 8, null).filter(textCapture, textCapture);

--- a/src/main/java/dev/justix/gtavtools/tools/casino/StartMission.java
+++ b/src/main/java/dev/justix/gtavtools/tools/casino/StartMission.java
@@ -119,10 +119,10 @@ public class StartMission extends Tool {
             this.waitingForCutDefinition = true;
         } else {
             keyPress("DOWN", 10);
-            sleep(15);
+            sleep(3_500);
 
             keyPress("ENTER", 10);
-            sleep(500);
+            sleep(15);
 
             this.waitingForCutDefinition = false;
         }

--- a/src/main/java/dev/justix/gtavtools/tools/mission/ReplayGlitch.java
+++ b/src/main/java/dev/justix/gtavtools/tools/mission/ReplayGlitch.java
@@ -1,7 +1,6 @@
 package dev.justix.gtavtools.tools.mission;
 
 import dev.justix.gtavtools.config.ApplicationConfig;
-import dev.justix.gtavtools.gui.components.settings.BooleanSetting;
 import dev.justix.gtavtools.logging.Level;
 import dev.justix.gtavtools.logging.Logger;
 import dev.justix.gtavtools.tools.Category;
@@ -35,8 +34,6 @@ public class ReplayGlitch extends Tool {
 
     public ReplayGlitch(Logger logger) {
         super(logger, Category.MISSION, "Replay Glitch");
-
-        addSetting(new BooleanSetting(this, "Casino", false));
     }
 
     @Override
@@ -72,7 +69,6 @@ public class ReplayGlitch extends Tool {
             final AtomicBoolean networkDisabled = new AtomicBoolean(false);
             final Object networkLock = new Object();
 
-            int telemetryPacketCount = 0;
             boolean connectionOpened = false;
 
             AtomicBoolean packetSent = new AtomicBoolean(false),
@@ -102,9 +98,6 @@ public class ReplayGlitch extends Tool {
 
                                     // Check if destination address is a telemetry server
                                     if(!telemetryServers.contains(destAddress.getHostAddress()))
-                                        continue;
-
-                                    if((++telemetryPacketCount) < 2 && booleanValue("Casino"))
                                         continue;
 
                                     connectionOpened = true;
@@ -185,8 +178,6 @@ public class ReplayGlitch extends Tool {
                                 String path = requestLine[1];
 
                                 if (!path.endsWith("/gameservices/Telemetry.asmx/SubmitCompressed")) {
-                                    telemetryPacketCount--;
-
                                     if(!DEBUG) {
                                         new Thread(() -> {
                                             if (packetSent.get()) return;

--- a/src/main/java/dev/justix/gtavtools/util/ImageUtil.java
+++ b/src/main/java/dev/justix/gtavtools/util/ImageUtil.java
@@ -224,6 +224,10 @@ public class ImageUtil {
             }
         }
 
+        // If less than 7.5% of the pixels are checked, the result is not reliable
+        if(checkImage2WhitePixelsOnly && checked < (image1Width * image1Height) * 0.075)
+            return 0d;
+
         return (double) matches / checked;
     }
 


### PR DESCRIPTION
- improved fingerprint hack results for 1920x1080 screens
- fixed a bug where the compare method would return 100% matches when the checked pixel count was very low
- removed Casino setting for the replay glitch since it isn't required for the glitch to work
- changed the mission start behaviour for the Casino Heist after cut definition